### PR TITLE
Use docker registry specifiers and remove bridge network

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-slim as build
+FROM docker://node:20-slim as build
 WORKDIR /app
 # Copy package files
 COPY package*.json ./
@@ -11,7 +11,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:alpine
+FROM docker://nginx:alpine
 # Copy the built assets from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 # Expose port 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,6 @@ services:
      dockerfile: Dockerfile
     depends_on:
       - mongodb
-    ports:
-      - "8000:8000"
-    networks:
-      - app-network
     environment:
       - MONGODB__DATABASE_NAME=quickgraph
       - MONGODB__URI=mongodb://root:example@mongodb:27017
@@ -17,31 +13,27 @@ services:
 
   client:
     image: quickgraph-client
+    ports:
+      - "3000:80"
     build:
       context: ./client
       dockerfile: Dockerfile
-    ports:
-      - "8080:80"
     depends_on:
       - server
       - docs
-    networks:
-      - app-network
     environment:
-      - VITE_API_BASE_URL=http://localhost:8000/api
-      - VITE_DOC_BASE_URL=http://localhost:4000
+      - VITE_API_BASE_URL=http://server:8000/api
+      - VITE_DOC_BASE_URL=http://docs:4000
 
   mongodb:
-    image: mongo:latest
+    image: docker.io/mongo:latest
     ports:
       - "27018:27017"
     volumes:
-      - mongodb_data:/data/db
+      - mongodb_data:/data/db:z
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example
-    networks:
-      - app-network
 
   docs:
     build:
@@ -51,13 +43,11 @@ services:
       - "4000:4000"
     volumes:
       - static_img:/app/static/img
-    networks:
-      - app-network
     depends_on:
       - init-static-img
 
   init-static-img:
-    image: curlimages/curl:latest
+    image: docker.io/curlimages/curl:latest
     user: root
     volumes:
       - static_img:/app/static/img
@@ -91,11 +81,6 @@ services:
       chmod -R 755 /app/static/img &&
       echo "Initialization complete"
       '
-
 volumes:
   mongodb_data:
   static_img:
-
-networks:
-  app-network:
-    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
      context: ./server
      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
     depends_on:
       - mongodb
     environment:
@@ -22,13 +24,11 @@ services:
       - server
       - docs
     environment:
-      - VITE_API_BASE_URL=http://server:8000/api
-      - VITE_DOC_BASE_URL=http://docs:4000
+      - VITE_API_BASE_URL=http://localhost:8000/api
+      - VITE_DOC_BASE_URL=http://localhost:4000
 
   mongodb:
     image: docker.io/mongo:latest
-    ports:
-      - "27018:27017"
     volumes:
       - mongodb_data:/data/db:z
     environment:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM docker://python:3.10-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
We are deploying quickgraph on podman which likes to have registry specifiers on the containers. 
I don't know the rationale behind the bridge network so I have just removed it in favour of the default network. 
I unpublished the API port as I'm not sure if end-users are meant to access it.